### PR TITLE
Update macOS runner version for Intel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
   build-macos-intel:
     name: Build macOS Binary (Intel)
     needs: update-version
-    runs-on: macos-13  # Intel runner
+    runs-on: macos-15-intel  # Intel runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch the macOS Intel release job from the macos-13 runner to macos-15-intel in the GitHub Actions workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->